### PR TITLE
Update nav_bootstrap_dropdown.html5

### DIFF
--- a/module/templates/nav_bootstrap_dropdown.html5
+++ b/module/templates/nav_bootstrap_dropdown.html5
@@ -27,7 +27,9 @@
 						<?php echo $itemHelper->getDropdownToggle(); ?>
 					</a>
 				<?php else: ?>
-					<a <?php echo $itemHelper; ?><?php echo $item['target']; ?>><?php echo $item['link']; ?></a>
+					<?php if(!empty($item['link'])): ?>
+						<a <?php echo $itemHelper; ?><?php echo $item['target']; ?>><?php echo $item['link']; ?></a>
+					<?php endif; ?>
 				<?php endif; ?>
 				<?php echo $item['subitems']; ?>
 			</li>


### PR DESCRIPTION
Fixes a bug that an empty <a> is showed if the nav-item is actually not showed because the user isn't logged in.
